### PR TITLE
Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/paulkre/bevy_image_export"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
   "bevy_render",
   "bevy_asset",
   "trace",
@@ -19,7 +19,7 @@ bevy = { version = "0.17", default-features = false, features = [
 image = { version = "0.25", default-features = false }
 futures = "0.3"
 futures-lite = "2.1"
-wgpu = "26"
+wgpu = "27"
 bytemuck = "1.13"
 thiserror = "2"
 
@@ -30,7 +30,7 @@ jpeg = ["image/jpeg", "bevy/jpeg"]
 exr = ["image/exr", "bevy/exr"]
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 image = { version = "0.25", default-features = false, features = ["exr"] }
 anyhow = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,9 @@ fn setup(
         Transform::from_translation(5.0 * Vec3::Z),
         children![(
             Camera3d::default(),
-            Camera {
-                // Connect the output texture to a camera as a RenderTarget.
-                target: RenderTarget::Image(output_texture_handle.clone().into()),
-                ..default()
-            },
+            // Connect the output texture to a camera as a RenderTarget.
+            RenderTarget::Image(output_texture_handle.clone().into()),
+            Camera::default(),
         )],
     ));
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -38,7 +38,7 @@ fn main() {
             GracePeriodPlugin::default(),
             export_plugin,
         ))
-        .insert_resource(AmbientLight {
+        .insert_resource(GlobalAmbientLight {
             color: Color::WHITE,
             brightness: 1000.0,
             affects_lightmapped_meshes: true,
@@ -92,10 +92,8 @@ fn setup(
         Transform::from_translation(4.2 * Vec3::Z),
         children![(
             Camera3d::default(),
-            Camera {
-                target: RenderTarget::Image(output_texture_handle.clone().into()),
-                ..default()
-            },
+            RenderTarget::Image(output_texture_handle.clone().into()),
+            Camera::default(),
         )],
     ));
 

--- a/examples/hdr.rs
+++ b/examples/hdr.rs
@@ -52,7 +52,7 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.insert_resource(AmbientLight {
+    commands.insert_resource(GlobalAmbientLight {
         brightness: 0.0,
         ..default()
     });
@@ -120,10 +120,8 @@ fn setup_camera(
         children![(
             Camera3d::default(),
             Hdr,
-            Camera {
-                target: RenderTarget::Image(output_texture_handle.clone().into()),
-                ..default()
-            },
+            RenderTarget::Image(output_texture_handle.clone().into()),
+            Camera::default(),
             tonemapping,
         )],
     ));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -54,7 +54,7 @@ impl RenderAsset for GpuImageExportSource {
     type Param = (SRes<RenderDevice>, SRes<RenderAssets<GpuImage>>);
 
     fn asset_usage(_: &Self::SourceAsset) -> RenderAssetUsages {
-        RenderAssetUsages::RENDER_WORLD
+        RenderAssetUsages::default()
     }
 
     fn prepare_asset(
@@ -172,7 +172,13 @@ fn save_buffer_to_disk(
                         mapping_tx.send(res).unwrap();
                     });
 
-                    if render_device.poll(PollType::Wait).is_err() {
+                    if render_device
+                        .poll(PollType::Wait {
+                            submission_index: None,
+                            timeout: None,
+                        })
+                        .is_err()
+                    {
                         break;
                     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,3 @@
-use bevy::prelude::error;
 use bytemuck::AnyBitPattern;
 use image::{EncodableLayout, ImageBuffer, Pixel, PixelWithColorType, Rgba};
 use std::fs::create_dir_all;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -92,7 +92,7 @@ fn test_basic() -> anyhow::Result<()> {
                 }),
             export_plugin,
         ))
-        .insert_resource(AmbientLight {
+        .insert_resource(GlobalAmbientLight {
             color: Color::WHITE,
             brightness: 1000.0,
             affects_lightmapped_meshes: true,
@@ -160,8 +160,8 @@ fn setup(
         Transform::from_translation(4.2 * Vec3::Z),
         children![(
             Camera3d::default(),
+            RenderTarget::Image(output_texture_handle.clone().into()),
             Camera {
-                target: RenderTarget::Image(output_texture_handle.clone().into()),
                 clear_color: ClearColorConfig::Custom(Color::BLACK),
                 ..default()
             },


### PR DESCRIPTION
Hi, thank you for this crate! 

This bumps the bevy version to 0.18 and fixes a few migration problems, namely:
1. Use `GlobalAmbientLight` instead of `AmbientLight` (see https://bevy.org/learn/migration-guides/0-17-to-0-18/#ambientlight-split-into-a-component-and-a-resource)
2. Move `RenderTarget` to component on the camera entity (see https://bevy.org/learn/migration-guides/0-17-to-0-18/#rendertarget-is-now-a-component). This also appears in the readme.
3. Explicitly specify timeout for the `PollTarget`. I don't know the details here, but the wgpu changelog mentioned that the previous default was a long timeout but explicitly setting it to `None` is "more likely what you want" than the previous default: (see https://github.com/gfx-rs/wgpu/releases).
4. And then finally: Change `RenderAssetUsages::RENDER_WORLD` to `RenderAssetUsages::default()`, since otherwise, we get an error message: 
> `bevy_image_export::plugin::GpuImageExportSource` with `RenderAssetUsages == RENDER_WORLD` cannot be extracted: The asset type does not support extraction. To clone the asset to the renderworld, use `RenderAssetUsages::default()`.

The last one I am not sure about, because I don't know the reason why it was set to `RENDER_WORLD` previously. This new setting seems to imply that the asset will be kept around after the rendering.

I also removed a unused import to clear up a warning.

Tests seem to run and produce the same result as before.